### PR TITLE
RA-1118 - Separated deleteAlert component

### DIFF
--- a/angular/openmrs-deleteAlert/delete-alert.component.js
+++ b/angular/openmrs-deleteAlert/delete-alert.component.js
@@ -1,0 +1,32 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+var template = require('./delete-alert.html');
+
+export default angular.module('openmrs-contrib-uicommons.delete-alert', []).component('deleteAlert', {
+	template: template,
+	controller: DeleteAlertController,
+	controllerAs: 'vm',
+	bindings: {
+		onUpdate: '&'
+	}
+}).name;
+
+export default function DeleteAlertController(){
+	var vm = this;
+
+	vm.isConfirmed = false;
+
+	vm.confirm = confirm;
+
+	function confirm(isConfirmed) {
+		vm.isConfirmed = isConfirmed;
+		vm.onUpdate({isConfirmed : vm.isConfirmed});
+	}
+}

--- a/angular/openmrs-deleteAlert/delete-alert.html
+++ b/angular/openmrs-deleteAlert/delete-alert.html
@@ -1,0 +1,15 @@
+<div class="dialog">
+	<div class="dialog-header">
+		<h3>Delete confirmation</h3>
+	</div>
+	<div class="dialog-content">
+		<p>Do You want to delete this forever?</p>
+		<br>
+		<button class="cancel" ng-click="vm.confirm(false)">
+			Cancel
+		</button>
+		<button class="confirm right"ng-click="vm.confirm(true)">
+			Delete
+		</button>
+	</div>
+</div>

--- a/angular/openmrs-list/openmrs-list.html
+++ b/angular/openmrs-list/openmrs-list.html
@@ -51,18 +51,4 @@
     <b>Loading more pages...</b>
 </div>
 
-<div class="dialog" ng-show="vm.deleteClicked">
-    <div class="dialog-header">
-        <h3>Delete confirmation</h3>
-    </div>
-    <div class="dialog-content">
-        <p>Do You want to delete this forever?</p>
-        <br>
-        <button class="cancel" ng-click="vm.updateDeleteConfirmation(false)">
-            Cancel
-        </button>
-        <button class="confirm right" ng-click="vm.updateDeleteConfirmation(true)">
-            Delete
-        </button>
-    </div>
-</div>
+<delete-alert ng-show="vm.deleteClicked" on-update="vm.updateDeleteConfirmation(isConfirmed)"></delete-alert>

--- a/openmrs-contrib-uicommons.js
+++ b/openmrs-contrib-uicommons.js
@@ -4,7 +4,8 @@ import header from './angular/openmrs-header/openmrs-header.component.js';
 import breadcrumbs from './angular/openmrs-breadcrumbs/openmrs-breadcrumbs.component.js';
 import conceptAutocomplete from './angular/openmrs-conceptAutocomplete/openmrs-conceptAutocomplete.component.js';
 import openmrsRest from './angular/openmrs-rest/openmrs-rest.js';
-import openmrsList from './angular/openmrs-list/openmrs-list.component.js'
+import openmrsList from './angular/openmrs-list/openmrs-list.component.js';
+import deleteAlert from './angular/openmrs-deleteAlert/delete-alert.component.js';
 
 var lib = angular.module('openmrs-contrib-uicommons',
 				[
@@ -12,7 +13,8 @@ var lib = angular.module('openmrs-contrib-uicommons',
 					'openmrs-contrib-uicommons.breadcrumbs', 
 					'openmrs-contrib-uicommons.rest',
 					'openmrs-contrib-uicommons.concept-autoComplete',
-					'openmrs-contrib-uicommons.openmrs-list'
+					'openmrs-contrib-uicommons.openmrs-list',
+					'openmrs-contrib-uicommons.delete-alert'
                 ]);
 
 module.exports = {
@@ -22,5 +24,6 @@ module.exports = {
 	conceptautocomplete : conceptAutocomplete,
 	openmrsRest : openmrsRest,
 	openmrsList : openmrsList,
+	deleteAlert : deleteAlert,
 	lib : lib
 };


### PR DESCRIPTION
deleteAlert is passed to uicommons and separated from openmrs-list in order to make deleteAlert component more universal and reusable.
conceptdictionary PR that implements this solution: https://github.com/rkorytkowski/openmrs-owa-conceptdictionary/pull/81