### PR TITLE
RA-1116 lacking explict injection

### DIFF
--- a/angular/openmrs-rest/openmrs-rest.js
+++ b/angular/openmrs-rest/openmrs-rest.js
@@ -93,7 +93,9 @@ function openmrsRest() {
 	return {
 		list: provideList,
 		get: provideGet,
-		$get: provideOpenmrsRest,
+		$get: ['openmrsApi', '$document', '$window', function(openmrsApi, $document, $window){
+			return provideOpenmrsRest(openmrsApi, $document, $window);
+		}]
 	};
 
 	function provideList(resource, query) {
@@ -108,7 +110,6 @@ function openmrsRest() {
 		}]
 	}
 
-	provideOpenmrsRest.$inject = ['$document', '$window'];
 	function provideOpenmrsRest(openmrsApi, $document, $window) {
 		var openmrsRest = {
 			list: list,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -45,7 +45,6 @@ if (env === 'production') {
     output: {
       comments: false,
     },
-    mangle: false,
     minimize: true,
     sourceMap: false,
     compress: {


### PR DESCRIPTION
@rkorytkowski It seems like the provideOpenmrsRest.$inject = ['openmrsApi', '$document', '$window' ]; doesn't work properly for some reason. I've changed the code and now it works fine but it doesn't follow the Angular style guide.  
If you have any idea how we could change the line mentioned above let me know :) 
