### PR TITLE
RA-1150 - Improved displaying openmrs-list as table

### DIFF
--- a/angular/openmrs-list/list.css
+++ b/angular/openmrs-list/list.css
@@ -52,3 +52,14 @@ a.nav-button-disabled-selected {
     -moz-user-select: none;
     -ms-user-select: none;
 }
+table.word-wrapper {
+    /* Warning: Needed for oldIE support, but words are broken up letter-by-letter */
+    -ms-word-break: break-all;
+    word-break: break-all;
+    /* Non standard for webkit */
+    overflow-wrap: break-word;
+    -webkit-hyphens: auto;
+    -moz-hyphens: auto;
+    -ms-hyphens: auto;
+    hyphens: auto;
+}

--- a/angular/openmrs-list/openmrs-list.html
+++ b/angular/openmrs-list/openmrs-list.html
@@ -26,7 +26,7 @@
     </div>
 
     <!--TABLE TYPE-->
-    <table ng-if="vm.showTable()">
+    <table ng-if="vm.showTable()" class="word-wrapper">
         <thead>
         <tr>
             <!--Main data header-->


### PR DESCRIPTION
Table is now able to break words in cells, which will prevent overextending width of cells when there is some really long string.