### PR TITLE
RA-1148/1453 - Search panel improvements

### DIFF
--- a/angular/openmrs-list/list.css
+++ b/angular/openmrs-list/list.css
@@ -63,3 +63,9 @@ table.word-wrapper {
     -ms-hyphens: auto;
     hyphens: auto;
 }
+
+/* Search Panel checkboxes and query field */
+#container{width:100%;} /* Wrapper */
+#left{float:left;width:150px;} /* Show retired checkbox */
+#right{float:right;width:300px;} /* Filter by class dropdown */
+#center{margin:0 auto;width:400px;} /* Search button and query field */

--- a/angular/openmrs-list/openmrs-list.component.spec.js
+++ b/angular/openmrs-list/openmrs-list.component.spec.js
@@ -59,7 +59,9 @@ describe('Concept dictionary controllers', function() {
                 }
             );
 
-            $httpBackend.expectGET('/ws/rest/v1/testres?includeAll=false&limit=10&startIndex=NaN&v=full').respond({"results": []});
+            $httpBackend.whenGET('/ws/rest/v1').respond({"results": []});
+            $httpBackend.whenGET('/ws/rest/v1/conceptclass').respond({"results": []});
+            $httpBackend.whenGET('/ws/rest/v1/testres?includeAll=false&limit=10&startIndex=NaN&v=full').respond({"results": []});
             $httpBackend.flush();
 
             expect(component.getType()).toEqualData('table');
@@ -108,6 +110,9 @@ describe('Concept dictionary controllers', function() {
                     "resourceVersion": "1.8"
                 }]
             };
+            $httpBackend.whenGET('/ws/rest/v1').respond({"results": []});
+            $httpBackend.whenGET('/ws/rest/v1/conceptclass').respond({"results": []});
+            $httpBackend.whenGET('/ws/rest/v1/conceptclass?includeAll=true&limit=10&source=&startIndex=0&v=full').respond(listAllTrueResponse);
             $httpBackend.whenGET('/ws/rest/v1/conceptclass?includeAll=true&limit=10&startIndex=NaN&v=full').respond(listAllTrueResponse);
             $httpBackend.whenGET('/ws/rest/v1/conceptclass?includeAll=true&limit=10&startIndex=0&v=full').respond(listAllTrueResponse);
 
@@ -121,6 +126,7 @@ describe('Concept dictionary controllers', function() {
                     "retired": false
                 }]
             };
+            $httpBackend.whenGET('/ws/rest/v1/conceptclass?includeAll=false&limit=10&source=&startIndex=0&v=full').respond(listAllFalseResponse);
             $httpBackend.whenGET('/ws/rest/v1/conceptclass?includeAll=false&limit=10&startIndex=NaN&v=full').respond(listAllFalseResponse);
             $httpBackend.whenGET('/ws/rest/v1/conceptclass?includeAll=false&limit=10&startIndex=0&v=full').respond(listAllFalseResponse);
 
@@ -128,6 +134,7 @@ describe('Concept dictionary controllers', function() {
 
             $httpBackend.flush();
             expect(component.data).toEqualData(listAllTrueResponse.results);
+
 
             component.listAll = false;
             component.getPage();
@@ -162,9 +169,11 @@ describe('Concept dictionary controllers', function() {
                 "description": "Drug",
                 "retired": true
             }]};
-
-
+            
+            $httpBackend.whenGET('/ws/rest/v1').respond({"results": []});
+            $httpBackend.whenGET('/ws/rest/v1/conceptclass').respond({"results": []});
             $httpBackend.whenGET('manifest.webapp').respond(500, "");
+            $httpBackend.whenGET('/ws/rest/v1/drug?includeAll=false&limit=10&source=&startIndex=0&v=full').respond(response);
             $httpBackend.whenGET('/ws/rest/v1/drug?includeAll=false&limit=10&startIndex=NaN&v=full').respond(response);
             $httpBackend.whenGET('/ws/rest/v1/drug?includeAll=false&limit=10&startIndex=0&v=full').respond(response);
             $httpBackend.flush();
@@ -174,39 +183,6 @@ describe('Concept dictionary controllers', function() {
             component.resolveComplexProperties = function () {
                 return false;
             };
-            $httpBackend.flush();
-        });
-
-        it('should request response by query', function() {
-
-            component = $componentController('openmrsList',
-                {
-                    $scope: scope
-                },
-                {
-                    enableSearch: true,
-                    resource: 'drug',
-                    columns: [
-                        {
-                            "property": "name",
-                            "label": "Concept.name"
-                        },
-                        {
-                            "property": "description",
-                            "label": "Description"
-                        }]
-                }
-            );
-            component.query = "testquery";
-            component.getPage();
-            $httpBackend.whenGET('manifest.webapp').respond(500, "");
-            $httpBackend.expectGET('/ws/rest/v1/drug?includeAll=false&limit=10&q=testquery&startIndex=0&v=full').respond({results : [{
-                "uuid": "c543d951-0201-4e20-94bd-64b44120991e",
-                "display": "Drug",
-                "name": "Drug",
-                "description": "Drug",
-                "retired": true
-            }]});
             $httpBackend.flush();
         });
     });

--- a/angular/openmrs-list/openmrs-list.html
+++ b/angular/openmrs-list/openmrs-list.html
@@ -1,11 +1,31 @@
 <!--MAIN WRAPPER-->
 <div ng-if="!vm.deleteClicked && !vm.retireClicked">
 
-    <!--Query field and search button-->
-    <div class="search-input" align="center" ng-if="vm.isSearchPanelVisible()">
-        <input class="field-display ui-autocomplete-input" id="inputNode" type="text" ng-model="vm.query"
-               ng-change="vm.timeoutRefresh()" autocomplete="off">
-        <button id="searchButton" name="searchButton" ng-click="vm.getData()">{{"Search" | translate}}</button>
+    <div id="container">
+
+        <div ng-if="vm.isButtonPanelVisible()" id="left">
+            <input type="checkbox" id="show-retired-checkbox" ng-model="vm.listAll" ng-change="vm.getPage()"><label for="show-retired-checkbox">Show retired</label></input>
+        </div>
+
+        <div ng-if="vm.isAdvancedSearchPossible()" id="right">
+            <div style="display:inline-block">
+                <select ng-model="vm.selectedAdvancedSearchDataUuid" ng-change="vm.getPage()" ng-options="advancedSearchData.uuid as advancedSearchData.display for advancedSearchData in vm.advancedSearchData">
+
+
+                    <option value="">Show All</option>
+
+
+                </select>
+            </div>
+            <label>Filter by {{vm.advancedSearchResourceLabel}}</label>
+        </div>
+
+        <div class="search-input" ng-if="vm.isSearchPanelVisible()" id="center">
+            <input class="field-display ui-autocomplete-input" id="inputNode" type="text" ng-model="vm.query"
+                   ng-change="vm.timeoutRefresh()" autocomplete="off">
+            <button id="searchButton" name="searchButton" ng-click="vm.getPage()">{{"Search" | translate}}</button>
+        </div>
+
     </div>
 
     <!--Empty query notification-->
@@ -96,6 +116,8 @@
                     <span ng-repeat="column in vm.columns">
                         <!-- First column -->
                        <a ng-href="{{vm.resolveRedirectLinks(data)}}" ng-if="$first">
+                           <span ng-if="vm.synonymOf(vm.query, data) && !data.retired">{{vm.synonymOf(vm.query, data)}} -> </span>
+                           <span ng-if="vm.synonymOf(vm.query, data) && data.retired"><del>{{vm.synonymOf(vm.query, data)}}</del> -> </span>
                         <strong>
                             <span ng-if="data.retired"><del>{{data[column.property]}}</del></span>
                             <span ng-if="!data.retired">{{data[column.property]}}</span>
@@ -129,6 +151,8 @@
                     <span ng-repeat="column in vm.columns">
                        <!-- First column -->
                        <span ng-if="$first">
+                           <span ng-if="vm.synonymOf(vm.query, data) && !data.retired">{{vm.synonymOf(vm.query, data)}} -> </span>
+                           <span ng-if="vm.synonymOf(vm.query, data) && data.retired"><del>{{vm.synonymOf(vm.query, data)}}</del> -> </span>
                         <strong>
                             <span ng-if="data.retired"><del>{{data[column.property]}}</del></span>
                             <span ng-if="!data.retired">{{data[column.property]}}</span>
@@ -162,7 +186,7 @@
 
     <!--Nav buttons-->
     <div ng-if="vm.isButtonPanelVisible() && vm.isWholeNavigationPanelVisible()" align="center" style="margin-bottom: 20px">
-        
+
         <!--Entries count selection-->
         <div align="left" style="padding: 5px;display:inline-block;float:left;">
             {{"Show" | translate}}

--- a/demo-app/controllers/search.controller.js
+++ b/demo-app/controllers/search.controller.js
@@ -2,38 +2,27 @@ ListController.$inject = [];
 
 export default function ListController(){
 	var vm = this;
-    vm.type = "table";
-    vm.resource = "conceptreferenceterm";
-    vm.limit = 5; //Default value
+    vm.type = "list";
+    vm.resource = "concept";
+    vm.limit = 10; //Default value
     vm.columns= [
         {
-            "property": "code",
-            "label": "Code"
+            "property": "name.name",
+            "label": "Concept.name"
         },
         {
-            "property": "name",
-            "label": "Name"
+            "property": "conceptClass.name",
+            "label":"class"
         },
         {
-            "property": "conceptSource.display",
-            "label": "Source"
+            "property": "uuid",
+            "label":"uuid"
         }];
     vm.actions = [
         {
-            "action":"edit",
-            "label":"Edit",
-            "link" : "#/reference/{uuid}"
-        },
-        {
-            "action":"retire",
-            "label":"Retire"
-        },
-        {
-            "action":"unretire",
-            "label":"unretire"
-        },
-        {
-            "action":"purge",
-            "label":"Delete"
-        }];
+            "action":"view",
+            "label":"View",
+            "link" : "#/concept/{uuid}"
+        }
+    ];
 }


### PR DESCRIPTION
Multiple fixes should be applied:
- search request should be not executed until query length is more than 2-3 letters - **DONE**
- show synonyms pointing to preferred name, e.g. searching for "aneamic" returns
Aneamic -> Aneamia - **DONE**
- be able to include/not include retired concepts via checkbox - **DONE**
- be able to search by code (reference map code) by simply typing in the search box: CIEL:121629 - **DONE** <br>
**NOTE: conceptReferenceTerm is using same logic (RA-1153)**
- be able to filter search by class (requires a new search handler in RESTWS) - Handler Created at https://github.com/openmrs/openmrs-module-webservices.rest/pull/217 **DONE** (I need to apply default value for dropdown)

NOTE:
This PR refers to https://github.com/openmrs/openmrs-module-webservices.rest/pull/217 and https://github.com/openmrs/openmrs-module-webservices.rest/pull/221 and should be merged after them