### PR TITLE
MAP-22 - Added customParams feature to openmrs-list

### DIFF
--- a/angular/openmrs-list/openmrs-list.component.js
+++ b/angular/openmrs-list/openmrs-list.component.js
@@ -26,7 +26,8 @@ export default angular.module('openmrs-contrib-uicommons.list', ['openmrs-contri
             enableSearch: '<',
             limit: '<',
             listAll: '<',
-            disableLinks: '<'
+            disableLinks: '<',
+            customParams: '<'
         }
     }).name;
 
@@ -359,6 +360,12 @@ function openmrsList(openmrsRest, openmrsNotification, $scope, $location) {
             includeAll: vm.getListAll(),
             startIndex: vm.entriesPerPage.value * vm.page - vm.entriesPerPage.value
         };
+
+        if (angular.isDefined(vm.customParams)) {
+            for (var i = 0; i < vm.customParams.length; i++) {
+                params[vm.customParams[i].property] = vm.customParams[i].value;
+            }
+        }
 
         if ((vm.query.indexOf(':') >= vm.minimumSourceLength && !vm.isAdvancedSearchModeOn())
             && (vm.resource == "concept" || vm.resource == "conceptreferenceterm")) {


### PR DESCRIPTION
This PR adapts to MAP-22 changes and brings new "custom params" feature to openmrs-list.
Its not possible to add some parameters and their values manually by passing object through custom-params attribute.