### PR TITLE
Show Retired checkbox display logic fix

### DIFF
--- a/angular/openmrs-list/openmrs-list.component.js
+++ b/angular/openmrs-list/openmrs-list.component.js
@@ -532,6 +532,16 @@ function openmrsList(openmrsRest, openmrsNotification, $scope, $location) {
     vm.showTableContent = showTableContent;
     vm.showTable = showTable;
     vm.showList = showList;
+    vm.isThereRetireAction = isThereRetireAction;
+
+    function isThereRetireAction() {
+        for (var i = 0; i < vm.actions.length; i++) {
+            if (vm.actions[i].action === 'retire' || vm.actions[i].action === 'unretire') {
+                return true;
+            }
+        }
+        return false;
+    }
 
     function showList() {
         return vm.getType() == 'list'

--- a/angular/openmrs-list/openmrs-list.html
+++ b/angular/openmrs-list/openmrs-list.html
@@ -3,7 +3,7 @@
 
     <div id="container" style="padding-bottom:25px">
 
-        <div ng-if="vm.isButtonPanelVisible()" id="left" style="padding-top: 17px">
+        <div ng-if="vm.isButtonPanelVisible() && vm.isThereRetireAction()" id="left" style="padding-top: 17px">
             <input type="checkbox" id="show-retired-checkbox" ng-model="vm.listAll" ng-change="vm.getPage()"><label for="show-retired-checkbox">Show retired</label></input>
         </div>
 


### PR DESCRIPTION
After this commit, "Show Retired" checkbox won't appear when its impossible/not-necessary (eg. in Show Datatypes view).
